### PR TITLE
fix: some URLs not being parsed on the homepage

### DIFF
--- a/components/home/demo.tsx
+++ b/components/home/demo.tsx
@@ -20,7 +20,7 @@ const Demo = () => {
         onSubmit={async (e) => {
           e.preventDefault();
           setSaving(true);
-          fetch(`/api/edge/links?url=${url}&hostname=dub.sh`, {
+          fetch(`/api/edge/links?url=${encodeURIComponent(url)}&hostname=dub.sh`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",


### PR DESCRIPTION
Fixes an error with some URLs being parsed incorrectly. See:

![image](https://user-images.githubusercontent.com/83243777/191861834-1025b376-5b3b-484d-ab8e-6316e551fb9d.png)
