### PR TITLE
fix: fix key regex pattern when managing links

### DIFF
--- a/components/app/modals/add-edit-link-modal.tsx
+++ b/components/app/modals/add-edit-link-modal.tsx
@@ -214,7 +214,7 @@ function AddEditLinkModal({
                 id="key"
                 required
                 autoFocus={false}
-                pattern="[\p{Letter}\p{Mark}-]+" // Unicode regex to match all languages (and omit all symbols except for dashes)
+                pattern="[\p{Letter}\p{Mark}\d-]+" // Unicode regex to match all languages (and omit all symbols except for dashes)
                 className={`${
                   keyExistsError
                     ? "border-red-300 text-red-900 placeholder-red-300 focus:border-red-500 focus:ring-red-500"


### PR DESCRIPTION
[This commit](https://github.com/steven-tey/dub/commit/f8b4bda4ad3d7f0cb0cbd48afd088e02273cb8df) forgot to account for numbers in links, noticed it while making other changes.