### PR TITLE
switch to node-html-parser for parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
     "cobe": "^0.6.2",
     "focus-trap-react": "^10.0.1",
     "framer-motion": "^7.6.12",
-    "he": "^1.2.0",
     "html-escaper": "^3.0.3",
     "i": "^0.3.7",
     "mailing-core": "^0.9.1",
     "ms": "^2.1.3",
     "next": "^13.0.5",
     "next-auth": "^4.17.0",
+    "node-html-parser": "^6.1.4",
     "nodemailer": "^6.8.0",
     "npm": "^9.1.2",
     "prisma": "^4.6.1",
@@ -63,7 +63,6 @@
     "swr": "^1.3.0",
     "tailwind-scrollbar-hide": "^1.1.7",
     "topojson-client": "^3.1.0",
-    "ultrahtml": "^1.0.1",
     "use-debounce": "^8.0.4"
   },
   "devDependencies": {

--- a/pages/api/edge/metatags.ts
+++ b/pages/api/edge/metatags.ts
@@ -67,7 +67,13 @@ const getHeadChildNodes = (ast: ReturnType<typeof getAst>) => {
 		};
 	});
 	const title = ast.querySelector("title").innerText;
-	const linkTags = ast.querySelectorAll("link").map((node) => node.attributes);
+	const linkTags = ast.querySelectorAll("link").map(({ attributes }) => {
+		const { rel, href } = attributes;
+		return {
+			rel,
+			href,
+		};
+	});
 
 	return { metaTags, title, linkTags };
 };

--- a/pages/api/edge/metatags.ts
+++ b/pages/api/edge/metatags.ts
@@ -1,135 +1,135 @@
 import { NextFetchEvent, NextRequest } from "next/server";
 import { parse } from "node-html-parser";
-import { getDomainWithoutWWW, isValidUrl } from "@/lib/utils";
+import { isValidUrl } from "@/lib/utils";
 import { ratelimit, recordMetatags } from "@/lib/upstash";
 import { getToken } from "next-auth/jwt";
 
 export const config = {
-	runtime: "experimental-edge",
+  runtime: "experimental-edge",
 };
 
 export default async function handler(req: NextRequest, ev: NextFetchEvent) {
-	if (req.method === "GET") {
-		let url = req.nextUrl.searchParams.get("url");
-		if (!isValidUrl(url)) {
-			return new Response("Invalid URL", { status: 400 });
-		}
+  if (req.method === "GET") {
+    let url = req.nextUrl.searchParams.get("url");
+    if (!isValidUrl(url)) {
+      return new Response("Invalid URL", { status: 400 });
+    }
 
-		// Rate limit if user is not logged in
-		const session = await getToken({
-			req,
-			secret: process.env.NEXTAUTH_SECRET,
-		});
-		if (!session?.email) {
-			const { success } = await ratelimit.limit("metatags");
-			if (!success) {
-				return new Response("Don't DDoS me pls 🥺", { status: 429 });
-			}
-		}
+    // Rate limit if user is not logged in
+    const session = await getToken({
+      req,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+    if (!session?.email) {
+      const { success } = await ratelimit.limit("metatags");
+      if (!success) {
+        return new Response("Don't DDoS me pls 🥺", { status: 429 });
+      }
+    }
 
-		const metatags = await getMetaTags(url, ev);
-		return new Response(JSON.stringify(metatags), {
-			status: 200,
-			headers: {
-				"Content-Type": "application/json",
-			},
-		});
-	} else {
-		return new Response(`Method ${req.method} Not Allowed`, { status: 405 });
-	}
+    const metatags = await getMetaTags(url, ev);
+    return new Response(JSON.stringify(metatags), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } else {
+    return new Response(`Method ${req.method} Not Allowed`, { status: 405 });
+  }
 }
 
 const getHtml = async (url: string) => {
-	const controller = new AbortController();
-	const timeoutId = setTimeout(() => controller.abort(), 5000); // timeout if it takes longer than 5 seconds
-	return await fetch(url, {
-		signal: controller.signal,
-		headers: {
-			"User-Agent": "dub-bot/1.0",
-		},
-	}).then((res) => {
-		clearTimeout(timeoutId);
-		return res.text();
-	});
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000); // timeout if it takes longer than 5 seconds
+  return await fetch(url, {
+    signal: controller.signal,
+    headers: {
+      "User-Agent": "dub-bot/1.0",
+    },
+  }).then((res) => {
+    clearTimeout(timeoutId);
+    return res.text();
+  });
 };
 
 const getAst = (html: string) => {
-	const ast = parse(html);
-	return ast;
+  const ast = parse(html);
+  return ast;
 };
 
 const getHeadChildNodes = (ast: ReturnType<typeof getAst>) => {
-	const metaTags = ast.querySelectorAll("meta").map(({ attributes }) => {
-		const property = attributes.property || attributes.name || attributes.href;
-		return {
-			property,
-			content: attributes.content,
-		};
-	});
-	const title = ast.querySelector("title").innerText;
-	const linkTags = ast.querySelectorAll("link").map(({ attributes }) => {
-		const { rel, href } = attributes;
-		return {
-			rel,
-			href,
-		};
-	});
+  const metaTags = ast.querySelectorAll("meta").map(({ attributes }) => {
+    const property = attributes.property || attributes.name || attributes.href;
+    return {
+      property,
+      content: attributes.content,
+    };
+  });
+  const title = ast.querySelector("title").innerText;
+  const linkTags = ast.querySelectorAll("link").map(({ attributes }) => {
+    const { rel, href } = attributes;
+    return {
+      rel,
+      href,
+    };
+  });
 
-	return { metaTags, title, linkTags };
+  return { metaTags, title, linkTags };
 };
 
 const getRelativeUrl = (url: string, imageUrl: string) => {
-	if (!imageUrl) {
-		return null;
-	}
-	if (isValidUrl(imageUrl)) {
-		return imageUrl;
-	}
-	const { protocol, host } = new URL(url);
-	const baseURL = `${protocol}//${host}`;
-	return new URL(imageUrl, baseURL).toString();
+  if (!imageUrl) {
+    return null;
+  }
+  if (isValidUrl(imageUrl)) {
+    return imageUrl;
+  }
+  const { protocol, host } = new URL(url);
+  const baseURL = `${protocol}//${host}`;
+  return new URL(imageUrl, baseURL).toString();
 };
 
 export const getMetaTags = async (url: string, ev: NextFetchEvent) => {
-	const html = await getHtml(url);
-	const headAst = getAst(html);
-	const { metaTags, title: pageTitle, linkTags } = getHeadChildNodes(headAst);
+  const html = await getHtml(url);
+  const headAst = getAst(html);
+  const { metaTags, title: pageTitle, linkTags } = getHeadChildNodes(headAst);
 
-	let object = {};
+  let object = {};
 
-	for (let k in metaTags) {
-		let { property, content } = metaTags[k];
+  for (let k in metaTags) {
+    let { property, content } = metaTags[k];
 
-		property && (object[property] = content);
-	}
+    property && (object[property] = content);
+  }
 
-	for (let m in linkTags) {
-		let { rel, href } = linkTags[m];
+  for (let m in linkTags) {
+    let { rel, href } = linkTags[m];
 
-		rel && (object[rel] = href);
-	}
+    rel && (object[rel] = href);
+  }
 
-	const title = object["og:title"] || object["twitter:title"] || pageTitle;
+  const title = object["og:title"] || object["twitter:title"] || pageTitle;
 
-	const description =
-		object["description"] ||
-		object["og:description"] ||
-		object["twitter:description"];
+  const description =
+    object["description"] ||
+    object["og:description"] ||
+    object["twitter:description"];
 
-	const image =
-		object["og:image"] ||
-		object["twitter:image"] ||
-		object["image_src"] ||
-		object["icon"] ||
-		object["shortcut icon"];
+  const image =
+    object["og:image"] ||
+    object["twitter:image"] ||
+    object["image_src"] ||
+    object["icon"] ||
+    object["shortcut icon"];
 
-	ev.waitUntil(
-		recordMetatags(url, title && description && image ? false : true),
-	);
+  ev.waitUntil(
+    recordMetatags(url, title && description && image ? false : true),
+  );
 
-	return {
-		title,
-		description,
-		image: getRelativeUrl(url, image),
-	};
+  return {
+    title,
+    description,
+    image: getRelativeUrl(url, image),
+  };
 };

--- a/pages/api/edge/metatags.ts
+++ b/pages/api/edge/metatags.ts
@@ -53,12 +53,8 @@ const getHtml = async (url: string) => {
   });
 };
 
-const getAst = (html: string) => {
-  const ast = parse(html);
-  return ast;
-};
-
-const getHeadChildNodes = (ast: ReturnType<typeof getAst>) => {
+const getHeadChildNodes = (html) => {
+  const ast = parse(html); // parse the html into AST format with node-html-parser
   const metaTags = ast.querySelectorAll("meta").map(({ attributes }) => {
     const property = attributes.property || attributes.name || attributes.href;
     return {
@@ -92,8 +88,7 @@ const getRelativeUrl = (url: string, imageUrl: string) => {
 
 export const getMetaTags = async (url: string, ev: NextFetchEvent) => {
   const html = await getHtml(url);
-  const headAst = getAst(html);
-  const { metaTags, title: pageTitle, linkTags } = getHeadChildNodes(headAst);
+  const { metaTags, title: pageTitle, linkTags } = getHeadChildNodes(html);
 
   let object = {};
 

--- a/pages/api/edge/metatags.ts
+++ b/pages/api/edge/metatags.ts
@@ -88,7 +88,7 @@ const getRelativeUrl = (url: string, imageUrl: string) => {
 
 export const getMetaTags = async (url: string, ev: NextFetchEvent) => {
   const html = await getHtml(url);
-  const { metaTags, title: pageTitle, linkTags } = getHeadChildNodes(html);
+  const { metaTags, title: titleTag, linkTags } = getHeadChildNodes(html);
 
   let object = {};
 
@@ -104,7 +104,7 @@ export const getMetaTags = async (url: string, ev: NextFetchEvent) => {
     rel && (object[rel] = href);
   }
 
-  const title = object["og:title"] || object["twitter:title"] || pageTitle;
+  const title = object["og:title"] || object["twitter:title"] || titleTag;
 
   const description =
     object["description"] ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -4715,7 +4715,7 @@ node-gyp@^9.0.0, node-gyp@^9.3.0:
     tar "^6.1.2"
     which "^2.0.2"
 
-node-html-parser@^6.1.1:
+node-html-parser@^6.1.1, node-html-parser@^6.1.4:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.4.tgz#763cd362497e427d51fc73dda3dcd8ac52ba85a3"
   integrity sha512-3muP9Uy/Pz7bQa9TNYVQzWJhNZMqyCx7xJle8kz2/y1UgzAUyXXShc1IcPaJy6u07CE3K5rQcRwlvHzmlySRjg==
@@ -6188,11 +6188,6 @@ uglify-js@^3.15.4, uglify-js@^3.5.1:
   version "3.17.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
   integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
-
-ultrahtml@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ultrahtml/-/ultrahtml-1.0.1.tgz#ed7fd8c1046ae36d176e320772132dd48f73a864"
-  integrity sha512-VDt8gmBR5DPrsfdLS4GQqncojcsLTKMW6iHKVN9l6TohU5bdn/OPv8AmV/0/PBR7Z3qBmMpJHqxRdQFaFA8B9g==
 
 unique-filename@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This PR makes the switch from `ultrahtml` to `node-html-parser` for parsing HTML, mainly because the former has some slight quirks in parsing weirdly-formatted attributes like `content` in meta tags. It also utilizes the library's `querySelector` API, and makes the codebase a tad bit more easy to read--and type safe--by reducing lines of code in the main logic. Using `node-html-parser` also removes the need to manually escape HTML entities that causes the JSON response to sometimes break.