### PR TITLE
feat: updated modal to use radix-ui

### DIFF
--- a/components/app/modals/link-qr-modal.tsx
+++ b/components/app/modals/link-qr-modal.tsx
@@ -18,20 +18,12 @@ import useUsage from "@/lib/swr/use-usage";
 import { SimpleLinkProps } from "@/lib/types";
 import { getApexDomain, linkConstructor } from "@/lib/utils";
 import IconMenu from "@/components/shared/icon-menu";
-import { Download, Photo } from "@/components/shared/icons";
+import { Download, Photo, QR } from "@/components/shared/icons";
 import Popover from "@/components/shared/popover";
 import toast from "react-hot-toast";
 import { useSession } from "next-auth/react";
 
-function LinkQRModalHelper({
-  showLinkQRModal,
-  setShowLinkQRModal,
-  props,
-}: {
-  showLinkQRModal: boolean;
-  setShowLinkQRModal: Dispatch<SetStateAction<boolean>>;
-  props: SimpleLinkProps;
-}) {
+function LinkQRModalHelper({ props }: { props: SimpleLinkProps }) {
   const anchorRef = useRef<HTMLAnchorElement>();
   const { project: { domain, logo } = {} } = useProject();
   const { avatarUrl, apexDomain } = useMemo(() => {
@@ -94,7 +86,14 @@ function LinkQRModalHelper({
   };
 
   return (
-    <Modal showModal={showLinkQRModal} setShowModal={setShowLinkQRModal}>
+    <Modal
+      trigger={
+        <button className="group rounded-full bg-gray-100 p-1.5 transition-all duration-75 hover:scale-105 hover:bg-blue-100 active:scale-95">
+          <span className="sr-only">Copy</span>
+          <QR className="text-gray-700 transition-all group-hover:text-blue-800" />
+        </button>
+      }
+    >
       <div className="inline-block w-full transform bg-white align-middle shadow-xl transition-all sm:max-w-md sm:rounded-2xl sm:border sm:border-gray-200">
         <div className="flex flex-col items-center justify-center space-y-3 border-b border-gray-200 px-4 py-4 pt-8 sm:px-16">
           {avatarUrl ? (
@@ -341,20 +340,9 @@ function QrDropdown({ download, qrData, showLogo, logo }) {
 }
 
 export function useLinkQRModal({ props }: { props: SimpleLinkProps }) {
-  const [showLinkQRModal, setShowLinkQRModal] = useState(false);
-
   const LinkQRModal = useCallback(() => {
-    return (
-      <LinkQRModalHelper
-        showLinkQRModal={showLinkQRModal}
-        setShowLinkQRModal={setShowLinkQRModal}
-        props={props}
-      />
-    );
-  }, [showLinkQRModal, setShowLinkQRModal, props]);
+    return <LinkQRModalHelper props={props} />;
+  }, [props]);
 
-  return useMemo(
-    () => ({ showLinkQRModal, setShowLinkQRModal, LinkQRModal }),
-    [showLinkQRModal, setShowLinkQRModal, LinkQRModal],
-  );
+  return useMemo(() => ({ LinkQRModal }), [LinkQRModal]);
 }

--- a/components/shared/modal.tsx
+++ b/components/shared/modal.tsx
@@ -1,31 +1,33 @@
 import { useRouter } from "next/router";
 import {
-  Dispatch,
-  SetStateAction,
+  PropsWithChildren,
   useCallback,
   useEffect,
   useRef,
+  useState,
 } from "react";
 import FocusTrap from "focus-trap-react";
 import { AnimatePresence, motion, useAnimation } from "framer-motion";
+import * as Dialog from "@radix-ui/react-dialog";
+
+interface ModalProps {
+  bgColor?: string;
+  trigger: React.ReactNode;
+  closeWithX?: boolean;
+}
 
 export default function Modal({
   children,
-  showModal,
-  setShowModal,
   bgColor = "bg-white",
   closeWithX,
-}: {
-  children: React.ReactNode;
-  showModal: boolean;
-  setShowModal: Dispatch<SetStateAction<boolean>>;
-  bgColor?: string;
-  closeWithX?: boolean;
-}) {
+  trigger,
+}: PropsWithChildren<ModalProps>) {
   const router = useRouter();
   const { key } = router.query;
   const mobileModalRef = useRef(null);
   const desktopModalRef = useRef(null);
+  const [isMobile, setIsMobile] = useState(false);
+  const [showModal, setShowModal] = useState(false);
 
   const closeModal = useCallback(
     (closeWithX?: boolean) => {
@@ -53,12 +55,14 @@ export default function Modal({
 
   const controls = useAnimation();
   const transitionProps = { type: "spring", stiffness: 500, damping: 30 };
+
   useEffect(() => {
-    controls.start({
-      y: 0,
-      transition: transitionProps,
-    });
-  }, []);
+    showModal &&
+      controls.start({
+        y: 0,
+        transition: transitionProps,
+      });
+  }, [showModal]);
 
   async function handleDragEnd(_, info) {
     const offset = info.offset.y;
@@ -72,59 +76,83 @@ export default function Modal({
     }
   }
 
+  useEffect(() => {
+    setIsMobile(window.innerWidth <= 639);
+    window.addEventListener("resize", () => {
+      setIsMobile(window.innerWidth <= 639);
+    });
+    return () => window.removeEventListener("resize", () => {});
+  }, []);
+
+  useEffect(() => {
+    isMobile && controls.start({ y: 0, transition: transitionProps });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobile]);
+
   return (
-    <AnimatePresence>
-      {showModal && (
-        <FocusTrap focusTrapOptions={{ initialFocus: false }}>
-          <div className="absolute">
-            <motion.div
-              ref={mobileModalRef}
-              key="mobile-modal"
-              className="group fixed inset-x-0 bottom-0 z-40 w-screen cursor-grab active:cursor-grabbing sm:hidden"
-              initial={{ y: "100%" }}
-              animate={controls}
-              exit={{ y: "100%" }}
-              transition={transitionProps}
-              drag="y"
-              dragDirectionLock
-              onDragEnd={handleDragEnd}
-              dragElastic={{ top: 0, bottom: 1 }}
-              dragConstraints={{ top: 0, bottom: 0 }}
-            >
-              <div
-                className={`h-7 ${bgColor} rounded-t-4xl -mb-1 flex w-full items-center justify-center border-t border-gray-200`}
-              >
-                <div className="-mr-1 h-1 w-6 rounded-full bg-gray-300 transition-all group-active:rotate-12" />
-                <div className="h-1 w-6 rounded-full bg-gray-300 transition-all group-active:-rotate-12" />
-              </div>
-              {children}
-            </motion.div>
-            <motion.div
-              ref={desktopModalRef}
-              key="desktop-modal"
-              className="fixed inset-0 z-40 hidden min-h-screen items-center justify-center sm:flex"
-              initial={{ scale: 0.95 }}
-              animate={{ scale: 1 }}
-              exit={{ scale: 0.95 }}
-              onMouseDown={(e) => {
-                if (desktopModalRef.current === e.target) {
-                  closeModal(closeWithX);
-                }
-              }}
-            >
-              {children}
-            </motion.div>
-            <motion.div
-              key="backdrop"
+    <Dialog.Root open={showModal} onOpenChange={setShowModal}>
+      <Dialog.Trigger asChild>{trigger}</Dialog.Trigger>
+      <AnimatePresence>
+        {showModal && (
+          <Dialog.Portal forceMount>
+            <Dialog.Overlay
+              forceMount
               className="fixed inset-0 z-30 bg-gray-100 bg-opacity-10 backdrop-blur"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              onClick={() => closeModal(closeWithX)}
             />
-          </div>
-        </FocusTrap>
-      )}
-    </AnimatePresence>
+            <Dialog.Content
+              className="overflow-hidden rounded-t-xl"
+              asChild
+              forceMount
+            >
+              {/* <FocusTrap /> breaks this modal. Probably not needed w/Radix UI  */}
+              {/* <FocusTrap focusTrapOptions={{ initialFocus: false }}> */}
+              <div className="absolute">
+                {isMobile ? (
+                  <motion.div
+                    ref={mobileModalRef}
+                    key="mobile-modal"
+                    className="group fixed inset-x-0 bottom-0 z-40 w-screen cursor-grab active:cursor-grabbing sm:hidden"
+                    initial={{ y: "100%" }}
+                    animate={controls}
+                    exit={{ y: "100%" }}
+                    transition={transitionProps}
+                    drag="y"
+                    dragDirectionLock
+                    onDragEnd={handleDragEnd}
+                    dragElastic={{ top: 0, bottom: 1 }}
+                    dragConstraints={{ top: 0, bottom: 0 }}
+                  >
+                    <div
+                      className={`h-7 ${bgColor} rounded-t-4xl -mb-1 flex w-full items-center justify-center border-t border-gray-200`}
+                    >
+                      <div className="-mr-1 h-1 w-6 rounded-full bg-gray-300 transition-all group-active:rotate-12" />
+                      <div className="h-1 w-6 rounded-full bg-gray-300 transition-all group-active:-rotate-12" />
+                    </div>
+                    {children}
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    ref={desktopModalRef}
+                    key="desktop-modal"
+                    className="fixed inset-0 z-40 hidden min-h-screen items-center justify-center sm:flex"
+                    initial={{ scale: 0.95 }}
+                    animate={{ scale: 1 }}
+                    exit={{ scale: 0.95 }}
+                    onMouseDown={(e) => {
+                      if (desktopModalRef.current === e.target) {
+                        closeModal(closeWithX);
+                      }
+                    }}
+                  >
+                    {children}
+                  </motion.div>
+                )}
+              </div>
+              {/* </FocusTrap> */}
+            </Dialog.Content>
+          </Dialog.Portal>
+        )}
+      </AnimatePresence>
+    </Dialog.Root>
   );
 }

--- a/components/shared/modal.tsx
+++ b/components/shared/modal.tsx
@@ -6,7 +6,6 @@ import {
   useRef,
   useState,
 } from "react";
-import FocusTrap from "focus-trap-react";
 import { AnimatePresence, motion, useAnimation } from "framer-motion";
 import * as Dialog from "@radix-ui/react-dialog";
 
@@ -97,15 +96,13 @@ export default function Modal({
           <Dialog.Portal forceMount>
             <Dialog.Overlay
               forceMount
-              className="fixed inset-0 z-30 bg-gray-100 bg-opacity-10 backdrop-blur"
+              className="fixed inset-0 z-30 bg-gray-100 bg-opacity-10 backdrop-blur transition-all"
             />
             <Dialog.Content
               className="overflow-hidden rounded-t-xl"
               asChild
               forceMount
             >
-              {/* <FocusTrap /> breaks this modal. Probably not needed w/Radix UI  */}
-              {/* <FocusTrap focusTrapOptions={{ initialFocus: false }}> */}
               <div className="absolute">
                 {isMobile ? (
                   <motion.div
@@ -148,7 +145,6 @@ export default function Modal({
                   </motion.div>
                 )}
               </div>
-              {/* </FocusTrap> */}
             </Dialog.Content>
           </Dialog.Portal>
         )}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@visx/tooltip": "^2.16.0",
     "cloudinary": "^1.32.0",
     "cobe": "^0.6.2",
-    "focus-trap-react": "^10.0.1",
     "framer-motion": "^7.6.12",
     "html-escaper": "^3.0.3",
     "i": "^0.3.7",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@next/font": "^13.0.5",
     "@prisma/client": "^4.6.1",
     "@radix-ui/react-accordion": "^1.0.1",
+    "@radix-ui/react-dialog": "^1.0.2",
     "@radix-ui/react-popover": "^1.0.2",
     "@radix-ui/react-slider": "^1.1.0",
     "@radix-ui/react-switch": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3116,21 +3116,6 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-focus-trap-react@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-10.0.1.tgz#5a50333f9753355765fcd7b83c6d2a59c5716c65"
-  integrity sha512-Av+O4JCT4/WnY25jnaOu1rysqhaD9aAhqAxxcrJbgKciZToIFmPng/WOrLJ1yHe6ntNmx1g0WhdeDfNCL1dmfA==
-  dependencies:
-    focus-trap "^7.1.0"
-    tabbable "^6.0.1"
-
-focus-trap@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.1.0.tgz#3226e977d76b1fd555c2e4f7ff91f10371f0f2cc"
-  integrity sha512-CuJvwUBfJCWcU6fc4xr3UwMF5vWnox4isXAixCwrPzCsPKOQjP9T+nTlYT2t+vOmQL8MOQ16eim99XhjQHAuiQ==
-  dependencies:
-    tabbable "^6.0.1"
-
 follow-redirects@^1.14.9:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
@@ -6058,11 +6043,6 @@ swr@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
   integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
-
-tabbable@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.0.1.tgz#427a09b13c83ae41eed3e88abb76a4af28bde1a6"
-  integrity sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA==
 
 tailwind-scrollbar-hide@^1.1.7:
   version "1.1.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,6 +811,27 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-dialog@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.0.2.tgz#2d7a0bfed478afc40ed6fc78d0f53242af55284e"
+  integrity sha512-EKxxp2WNSmUPkx4trtWNmZ4/vAYEg7JkAfa1HKBUnaubw9eHzf1Orr9B472lJYaYz327RHDrd4R95fsw7VR8DA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-dismissable-layer" "1.0.2"
+    "@radix-ui/react-focus-guards" "1.0.0"
+    "@radix-ui/react-focus-scope" "1.0.1"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-portal" "1.0.1"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.1"
+    "@radix-ui/react-slot" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
 "@radix-ui/react-direction@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.0.0.tgz#a2e0b552352459ecf96342c79949dd833c1e6e45"


### PR DESCRIPTION
I only updated the `<LinkQRModal />` to show how the open/closed state of the modal is happened within the new `<Modal/>` itself. 

![dub-modal](https://user-images.githubusercontent.com/17864504/208003914-185009cd-aa1a-495e-8a5c-cbc0fd8611a4.gif)
