### PR TITLE
Fix `z` value on stats pages

### DIFF
--- a/app/ui/stats/index.tsx
+++ b/app/ui/stats/index.tsx
@@ -128,7 +128,7 @@ export default function Stats({
         <Toggle />
         <div className="mx-auto grid max-w-4xl gap-5">
           <Clicks />
-          <div className="z-10 grid grid-cols-1 gap-5 md:grid-cols-2">
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
             <Locations />
             <Devices />
             <Referer />

--- a/app/ui/stats/toggle.tsx
+++ b/app/ui/stats/toggle.tsx
@@ -34,7 +34,7 @@ export default function Toggle() {
 
   return (
     <div
-      className={cn("sticky top-[6.95rem] z-20 mb-5 bg-gray-50 py-3 md:py-5", {
+      className={cn("sticky top-[6.95rem] z-10 mb-5 bg-gray-50 py-3 md:py-5", {
         "top-14": basePath.startsWith("/stats"),
         "top-6 md:top-0": modal,
         "shadow-md": scrolled && !modal,

--- a/components/stats/index.tsx
+++ b/components/stats/index.tsx
@@ -89,7 +89,7 @@ export default function Stats({ staticDomain }: { staticDomain?: string }) {
         <Toggle />
         <div className="mx-auto grid max-w-4xl gap-5">
           <Clicks />
-          <div className="z-10 grid grid-cols-1 gap-5 sm:grid-cols-2">
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
             <Locations />
             <Devices />
             <Referer />

--- a/components/stats/toggle.tsx
+++ b/components/stats/toggle.tsx
@@ -37,7 +37,7 @@ export default function Toggle() {
 
   return (
     <div
-      className={cn("sticky top-[6.95rem] z-20 mb-5 bg-gray-50 py-3 md:py-5", {
+      className={cn("sticky top-[6.95rem] z-10 mb-5 bg-gray-50 py-3 md:py-5", {
         "top-14": basePath.startsWith("/stats"),
         "top-6": modal,
         "shadow-md": scrolled && !modal,


### PR DESCRIPTION
Fix `z` value on stats pages to prevent popovers displaying behind components.

Before:
![image](https://github.com/steven-tey/dub/assets/50220137/2a531640-9c04-4285-b039-d5a95bc92378)

After:
![image](https://github.com/steven-tey/dub/assets/50220137/0e74ca1b-daf2-4704-ae9e-377c450a1c89)
