### PR TITLE
Prevent removing only user from project.

### DIFF
--- a/pages/api/projects/[slug]/users.ts
+++ b/pages/api/projects/[slug]/users.ts
@@ -33,14 +33,24 @@ export default withProjectAuth(async (req, res, project) => {
       return res.status(400).end("Missing userId");
     }
 
-    const usersCount = await prisma.projectUsers.count({
+    const projectUser = await prisma.projectUsers.findUnique({
       where: {
-        projectId: project.id,
+        userId_projectId: {
+          projectId: project.id,
+          userId,
+        },
+      },
+      select: {
+        role: true,
       },
     });
 
-    if (count === 1) {
-      return res.status(400).end("Cannot remove only user");
+    if (projectUser?.role === "owner") {
+      return res
+        .status(400)
+        .end(
+          "Cannot remove owner from project. Please transfer ownership to another user first.",
+        );
     }
 
     const response = await prisma.projectUsers.delete({

--- a/pages/api/projects/[slug]/users.ts
+++ b/pages/api/projects/[slug]/users.ts
@@ -32,6 +32,17 @@ export default withProjectAuth(async (req, res, project) => {
     if (!userId) {
       return res.status(400).end("Missing userId");
     }
+
+    const usersCount = await prisma.projectUsers.count({
+      where: {
+        projectId: project.id,
+      },
+    });
+
+    if (count === 1) {
+      return res.status(400).end("Cannot remove only user");
+    }
+
     const response = await prisma.projectUsers.delete({
       where: {
         userId_projectId: {


### PR DESCRIPTION
Prevent removing the only user from a project so that it is just lost to the void.

![image](https://github.com/steven-tey/dub/assets/50220137/92cb3b29-8475-4428-8088-fa308952442f)

Ideally, this would also need to be fixed in the UI, but this is a simple fix for now.

I have also written an email to support asking for the project back as it's just out there with no members.