### PR TITLE
Updated dicebear avatar to be the latest version

### DIFF
--- a/components/layout/app/user-dropdown.tsx
+++ b/components/layout/app/user-dropdown.tsx
@@ -134,7 +134,7 @@ export default function UserDropdown() {
               alt={session?.user?.email || "Avatar for logged in user"}
               src={
                 session?.user?.image ||
-                `https://avatars.dicebear.com/api/micah/${session?.user?.email}.svg`
+                `https://api.dicebear.com/6.x/identicon/svg?backgroundType=solid&seed=${session?.user?.email}&scale=50`
               }
               width={40}
               height={40}


### PR DESCRIPTION
I noticed the method used to fetch the avatar is not the latest as per dicebear documentation.

Plus there's no way for the user to change their avatar. Especially when their avatar does not align their race or gender. 

So I suggest fetching the cool and neutral space-invader style "Identicon" avatars using version 6.x of Dicebear.