### PR TITLE
Fix default redirects not being checked on new domain

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -62,7 +62,7 @@ export default async function middleware(req: NextRequest, ev: NextFetchEvent) {
     return RootMiddleware(req, ev);
   }
 
-  if (domain === "dub.sh" && DEFAULT_REDIRECTS[key]) {
+  if ((domain === "dub.sh" || domain === "dub.co") && DEFAULT_REDIRECTS[key]) {
     return NextResponse.redirect(DEFAULT_REDIRECTS[key]);
   }
 


### PR DESCRIPTION
Noticed that the default redirects weren't being checked in the middleware so fixed it.

Haven't tested yet , just submitted it.