### PR TITLE
Add CORS header to metatags api

### DIFF
--- a/pages/api/edge/metatags.ts
+++ b/pages/api/edge/metatags.ts
@@ -35,6 +35,7 @@ export default async function handler(req: NextRequest, ev: NextFetchEvent) {
       status: 200,
       headers: {
         "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
       },
     });
   } else {


### PR DESCRIPTION
Thanks for the project!

I was wondering if you meant to allow cross-origin requests to the metadata api? I've enabled it in this PR if you're interested.