### PR TITLE
Follow up to Add CORS header to metatags api (OPTIONS request)

### DIFF
--- a/app/dub.co/tools/metatags/content.tsx
+++ b/app/dub.co/tools/metatags/content.tsx
@@ -49,7 +49,7 @@ export default function MetatagsContent() {
           defaultValue={url}
           onChange={(e) =>
             router.replace(
-              `/metatags${
+              `/tools/metatags${
                 e.target.value.length > 0 ? `?url=${e.target.value}` : ""
               }`,
             )

--- a/pages/api/edge/metatags.ts
+++ b/pages/api/edge/metatags.ts
@@ -38,6 +38,14 @@ export default async function handler(req: NextRequest, ev: NextFetchEvent) {
         "Access-Control-Allow-Origin": "*",
       },
     });
+  } else if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+      },
+    });
   } else {
     return new Response(`Method ${req.method} Not Allowed`, { status: 405 });
   }


### PR DESCRIPTION
This PR is a follow up to #347 to also add CORS headers to the `OPTIONS` request that the browser sends before making the actual request.

This one I tested using my own vercel app and it's fully working, so there shouldn't need to be any further changes after this one.

Thanks!