### PR TITLE
[Docs] Add setup for /docs using Vercel rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "rewrites": [
+    {
+      "source": "/docs",
+      "destination": "https://dub.mintlify.dev/docs"
+    },
+    {
+      "source": "/docs/:match*",
+      "destination": "https://dub.mintlify.dev/docs/:match*"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

This PR adds adds the setup for the Mintlify docs to be hosted at `dub.sh/docs` using the [Vercel rewrites](https://vercel.com/docs/edge-network/rewrites) setup.